### PR TITLE
Investigate iso2022jp encoding

### DIFF
--- a/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
+++ b/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
@@ -27,9 +27,12 @@ struct FileAnalyzer {
     private static let defaultSuggestedEncodings: [String.Encoding] = []
     
     // Default fallback encoding array
-    // These are tried in order if BOM, strict UTF-8, and ICU detection all fail
+    // These are tried in order if BOM, ISO-2022-JP, strict UTF-8, and ICU detection all fail
     // Ordered by: strictness > regional relevance > rarity
     // Priority: Japanese > Korean > Chinese > Western > UTF-16/32 without BOM (rare)
+    //
+    // Note: ISO-2022-JP is included here as a safety net, but it's typically detected
+    // earlier via escape sequence detection (Step 2) before reaching fallback
     //
     // Rationale for UTF-16/32 placement at end:
     // - UTF-16/32 without BOM are extremely rare in practice
@@ -37,7 +40,7 @@ struct FileAnalyzer {
     // - Statistical detection (ICU) is unreliable for BOM-less UTF-16
     // - Placing at end ensures other likely encodings are tried first
     private static let defaultFallbackEncodings: [String.Encoding] = [
-        .iso2022JP,                 // Japanese JIS - highly structured, low false positive rate
+        .iso2022JP,                 // Japanese JIS - safety net (normally caught by Step 2)
         .japaneseEUC,               // Japanese EUC-JP
         .shiftJIS,                  // Japanese Shift-JIS
         cfEncoding(.EUC_KR),        // Korean EUC-KR

--- a/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
+++ b/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
@@ -21,11 +21,10 @@ struct FileAnalyzer {
     
     // Default encoding suggestion array for ICU detection
     // Can be customized via the suggestedEncodings parameter in detection methods
-    // ICU performs statistical analysis; we only suggest UTF-8 to guide its heuristics
-    // Other encodings are handled by strict validation or fallback mechanisms
-    private static let defaultSuggestedEncodings: [String.Encoding] = [
-        .utf8  // UTF-8 only - ICU is effective at detecting UTF-8 patterns
-    ]
+    // Empty array allows ICU to use its full statistical analysis without bias
+    // This enables detection of ISO-2022-JP and other encodings that may be
+    // incorrectly detected as UTF-8 when UTF-8 is suggested
+    private static let defaultSuggestedEncodings: [String.Encoding] = []
     
     // Default fallback encoding array
     // These are tried in order if BOM, strict UTF-8, and ICU detection all fail

--- a/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
+++ b/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
@@ -166,9 +166,10 @@ struct FileAnalyzer {
                 // Immediate binary detection on null byte
                 return true
             } else if byte < 0x20 {
-                // Check for control characters (excluding common whitespace)
-                // Allow: TAB(0x09), LF(0x0A), CR(0x0D), FF(0x0C)
-                if byte != 0x09 && byte != 0x0A && byte != 0x0D && byte != 0x0C {
+                // Check for control characters (excluding common whitespace and escape sequences)
+                // Allow: TAB(0x09), LF(0x0A), CR(0x0D), FF(0x0C), ESC(0x1B)
+                // ESC(0x1B) is needed for ISO-2022-JP encoding
+                if byte != 0x09 && byte != 0x0A && byte != 0x0D && byte != 0x0C && byte != 0x1B {
                     suspiciousCount += 1
                 }
             }

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -224,7 +224,12 @@ exit 0
 ## Technical Notes
 
 ### Encoding Detection
-- Text encoding is detected using the existing FileAnalyzer logic
+- Text encoding is detected using FileAnalyzer's multi-stage detection:
+  1. BOM detection (UTF-8/16/32)
+  2. ISO-2022-JP escape sequence detection
+  3. Strict UTF-8 validation
+  4. ICU statistical analysis
+  5. Priority-based fallback (Japanese/Korean/Chinese/Western encodings)
 - Detected encoding is used to decode text before formatting
 - RTF output is always UTF-8 encoded
 


### PR DESCRIPTION
   ## Summary

   This PR fixes ISO-2022-JP encoding detection issues that caused garbled text in QuickLook previews.

   ## Root Cause Analysis

   ISO-2022-JP files were being incorrectly detected and decoded as UTF-8, resulting in garbled text. Three issues were identified:

   1. **ESC character not allowed in binary detection**: ESC (0x1B) was treated as a suspicious control character
   2. **UTF-8 bias in ICU detection**: Suggesting UTF-8 to ICU caused ISO-2022-JP files to be misdetected as UTF-8
   3. **ISO-2022-JP passes strict UTF-8 validation**: ISO-2022-JP uses only ASCII bytes (0x00-0x7F), so it passes UTF-8 validation and gets 
   decoded incorrectly

   ## Changes

   ### Code Changes

   1. **Allow ESC character in binary detection** (fe714b9)
      - Modified `isBinaryData()` to allow ESC (0x1B) control character
      - Required for ISO-2022-JP escape sequences

   2. **Remove UTF-8 suggestion bias from ICU detection** (f4ec122)
      - Changed `defaultSuggestedEncodings` from `[.utf8]` to `[]`
      - Allows ICU to use full statistical analysis without bias

   3. **Add ISO-2022-JP escape sequence detection** (c1b5a90)
      - Added `hasISO2022JPEscapeSequences()` function
      - Detects ISO-2022-JP escape sequences (ESC $ B, ESC ( B, etc.)
      - Positioned before strict UTF-8 validation to prevent false positives

   ### Documentation Updates (1688ac7)

   Updated documentation in FileAnalyzer.swift, README.md, and FEATURES.md to reflect:
   - New encoding detection order with ISO-2022-JP as Step 2
   - ICU using empty suggestions (no bias)
   - ESC character allowance in binary detection
   - Detailed multi-stage encoding detection process

   ## New Encoding Detection Order

   1. BOM detection
   2. **ISO-2022-JP escape sequence detection** (NEW)
   3. Strict UTF-8 validation
   4. ICU statistical detection (with empty suggestions)
   5. Priority-based fallback
   6. Lossy UTF-8

   ## Testing

   - ✅ ISO-2022-JP files now display correctly without garbled text
   - ✅ UTF-8, EUC-JP, and Shift-JIS detection remains unaffected
   - ✅ Build succeeds with no errors
   - ✅ All documentation updated to reflect implementation

   ## Related Files

   - `QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift`
   - `README.md`
   - `docs/FEATURES.md`
   - Test file: `QLStephenSwift/test_files/test_iso2022jp`
