### PR TITLE
Preview empty files

### DIFF
--- a/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
+++ b/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
@@ -114,7 +114,13 @@ struct FileAnalyzer {
     }
     
     static func analyze(fileURL: URL) throws -> AnalysisResult {
-        // Get file size
+        // Handle empty files
+        let fileSize = try getFileSize(for: fileURL)
+        if fileSize == 0 {
+            // Treat zero-byte files as empty UTF-8 text instead of failing
+            return AnalysisResult(isTextFile: true, encoding: .utf8, mimeType: "text/plain")
+        }
+
         // For encoding detection, we only need a sample
         guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
             throw AnalysisError.cannotOpenFile

--- a/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
+++ b/QLStephenSwift/QLStephenSwiftPreview/FileAnalyzer.swift
@@ -55,62 +55,10 @@ struct FileAnalyzer {
         .utf32LittleEndian          // UTF-32 LE without BOM (extremely rare)
     ]
     
-    enum FileType {
-        case text(encoding: String.Encoding, string: String)
-        case binary
-    }
-    
     struct AnalysisResult {
         let isTextFile: Bool
         let encoding: String.Encoding
         let mimeType: String
-    }
-    
-    static func analyzeFile(fileURL: URL) throws -> FileType {
-        // Get file size
-        let fileSize = try getFileSize(for: fileURL)
-        
-        // Determine how much data to read based on file size
-        // Note: For files ≤5MB, entire file is loaded into memory to ensure accurate
-        // encoding detection and complete text decoding. For larger files, only the
-        // first 8KB is read to minimize memory usage. This trades memory for accuracy.
-        let shouldReadFull = fileSize <= maxFullReadBytes
-        let dataToAnalyze: Data
-        
-        if shouldReadFull {
-            // Read entire file for small files (≤5MB)
-            // Memory impact: Up to 5MB per file. QuickLook typically processes one file
-            // at a time, so concurrent memory pressure is minimal.
-            guard let fullData = try? Data(contentsOf: fileURL), !fullData.isEmpty else {
-                throw AnalysisError.cannotReadFile
-            }
-            dataToAnalyze = fullData
-        } else {
-            // Read only sample for large files (>5MB)
-            // Memory impact: Fixed 8KB per file regardless of file size
-            guard let fileHandle = try? FileHandle(forReadingFrom: fileURL) else {
-                throw AnalysisError.cannotOpenFile
-            }
-            defer { try? fileHandle.close() }
-            
-            guard let sampleData = try? fileHandle.read(upToCount: maxBytesToCheck),
-                  !sampleData.isEmpty else {
-                throw AnalysisError.cannotReadFile
-            }
-            dataToAnalyze = sampleData
-        }
-        
-        // Apply cheap binary heuristic first
-        if isBinaryData(dataToAnalyze) {
-            return .binary
-        }
-        
-        // Detect encoding and decode
-        if let (encoding, text) = detectEncodingAndDecode(data: dataToAnalyze) {
-            return .text(encoding: encoding, string: text)
-        }
-        
-        return .binary
     }
     
     static func analyze(fileURL: URL) throws -> AnalysisResult {


### PR DESCRIPTION
Hello,

This resolves #20 and adds support for empty files. They will now preview as blank text fields.

It also removes some unused code that seemed like it should have either been updated to maintain parity, or removed, and I chose removal. See the commit messages for more detail.

<img width="669" alt="Screenshot 2026-01-17 at 12 41 34 AM" src="https://github.com/user-attachments/assets/960b4445-c9fd-47e5-b0ab-affd72060fb2" />
