### PR TITLE
docs: fix Homebrew installation command in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ QLStephenSwift is a complete rewrite of the legacy [QLStephen](https://github.co
 Installable via Homebrew Cask:
 
 ```bash
-brew tap MyCometG3/qlstephenswift && brew install --cask qlstephenswift
+brew install --cask MyCometG3/qlstephenswift/qlstephenswift
 ```
 
 ### Pre-built Application


### PR DESCRIPTION
Homebrew have recently introduced the [Tap Trust](https://docs.brew.sh/Tap-Trust) mechanism, which means that directly installing a cask after tapping a repo as suggested by the README no longer works. Instead, you have to `brew trust --cask MyCometG3/qlstephenswift/qlstephenswift` or `brew trust MyCometG3/qlstephenswift` before installing.

Therefore this PR changes the README to suggest installing using fully-qualified name instead (this install method will automatically trust the named formulae/cask).